### PR TITLE
fix: закрывать мобильное меню при скролле вниз

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -42,7 +42,8 @@ function Header({ hidden, fixed, handleAuthModalOpen }) {
   };
 
   useEffect(() => {
-    hidden && handleClickCloseMenu();
+    hidden && isMenuOpened && handleClickCloseMenu();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hidden]);
 
   return (

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -20,7 +20,7 @@ Header.propTypes = {
 function Header({ hidden, fixed, handleAuthModalOpen }) {
   const [isMenuOpened, setIsMenuOpened] = useState(false);
   const { user } = useAuth();
-  console.log('header');
+
   const handleClickOpenMenu = () => {
     setIsMenuOpened(true);
   };

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 import HeaderNavigation from '../HeaderMenu/HeaderNavigation';
@@ -20,7 +20,7 @@ Header.propTypes = {
 function Header({ hidden, fixed, handleAuthModalOpen }) {
   const [isMenuOpened, setIsMenuOpened] = useState(false);
   const { user } = useAuth();
-
+  console.log('header');
   const handleClickOpenMenu = () => {
     setIsMenuOpened(true);
   };
@@ -37,6 +37,10 @@ function Header({ hidden, fixed, handleAuthModalOpen }) {
     setIsMenuOpened(false);
     handleAuthModalOpen();
   };
+
+  useEffect(() => {
+    hidden && handleClickCloseMenu();
+  }, [hidden]);
 
   return (
     <header

--- a/src/components/Header/header.css
+++ b/src/components/Header/header.css
@@ -76,17 +76,21 @@
   .header {
     padding: 44px 127px 0;
     transition: all 200ms ease-in-out;
+    display: grid;
+    grid-template: 1fr / max-content 1fr max-content;
   }
 
   .header__logo {
     margin: auto;
     font-size: 17px;
-    line-height: 1;
+    line-height: 1.7;
+    grid-column: 1 / 4;
+    grid-row: 1;
   }
 
   .header__button-login {
     display: none;
-    margin-left: 20px;
+    margin-left: 10px;
   }
 
   .header__button-login_show {
@@ -99,6 +103,8 @@
 
   .header__action {
     order: -1;
+    grid-column: 1 / 2;
+    grid-row: 1;
   }
 }
 

--- a/src/components/HeaderMenu/header-mobile-menu.css
+++ b/src/components/HeaderMenu/header-mobile-menu.css
@@ -1,62 +1,69 @@
+.mobile-menu {
+  display: flex;
+  align-items: center;
+  grid-column: 3 / 4;
+  grid-row: 1;
+}
+
 .mobile-menu__icon {
-    display: none;
-    width: 30px;
-    height: 20px;
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-size: cover;
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
+  display: none;
+  width: 30px;
+  height: 20px;
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
 }
 
 .mobile-menu__panel {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 40px 15px 30px;
-    border-radius: 0 0 30px 30px;
-    position: absolute;
-    top: 74px;
-    left: 0;
-    width: 100%;
-    background-color: rgba(243, 242, 242, 1);
-    z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 15px 30px;
+  border-radius: 0 0 30px 30px;
+  position: absolute;
+  top: 74px;
+  left: 0;
+  width: 100%;
+  background-color: rgba(243, 242, 242, 1);
+  z-index: 3;
 }
 
 .mobile-menu__panel_hidden {
-    display: none;
+  display: none;
 }
 
 .mobile-menu__wrapper {
-    padding: 0 15px;
-    margin-bottom: 158px;
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0px, max-content));
-    grid-gap: 26px;
+  padding: 0 15px;
+  margin-bottom: 158px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0px, max-content));
+  grid-gap: 26px;
 }
 
 .backdrop {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 2;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
 }
 
 @media (max-width: 1024px) {
-    .mobile-menu__icon {
-        display: inline-block;
-    }
+  .mobile-menu__icon {
+    display: inline-block;
+  }
 }
 
 @media (max-width: 640px) {
-    .mobile-menu__panel {
-        top: 44px;
-    }
+  .mobile-menu__panel {
+    top: 44px;
+  }
 
-    .mobile-menu__wrapper {
-        margin-bottom: 50px;
-    }
+  .mobile-menu__wrapper {
+    margin-bottom: 50px;
+  }
 }


### PR DESCRIPTION
Очередной колоссально радикальный пулреквест. Привязал состояние видимости меню к видимости хедера. Тупо, банально, вроде работает. 